### PR TITLE
Preinstall Phalcon dev-tools on app container

### DIFF
--- a/application/public/index.php
+++ b/application/public/index.php
@@ -1,3 +1,0 @@
-<?php
-
-phpinfo();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,9 +101,7 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./application:/project
-      - ./cache:/project/cache
-      - ./logs:/project/logs
+      - .:/project
       - ./conf/php/cli.ini:/etc/php/7.0/cli/conf.d/100-custom.ini
       - ./conf/php/fpm.ini:/etc/php/7.0/fpm/conf.d/100-custom.ini
     depends_on:

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -8,6 +8,9 @@ ENV PROVISION_CONTEXT "development"
 # Deploy scripts/configurations
 COPY bin/*.sh /opt/docker/provision/entrypoint.d/
 
-RUN \
+RUN mkdir -p /vendor \
+    && composer --working-dir=/vendor require phalcon/devtools \
+    && ln -s /vendor/vendor/phalcon/devtools/phalcon.php /usr/local/bin/phalcon \
+    && chmod ugo+x /usr/local/bin/phalcon \
     # Custom provisions
-    chmod +x /opt/docker/provision/entrypoint.d/*.sh \
+    && chmod +x /opt/docker/provision/entrypoint.d/*.sh \

--- a/variables.env.example
+++ b/variables.env.example
@@ -17,7 +17,7 @@ PMA_USER=phalcon
 PMA_PASSWORD=secret
 
 # Application
-WEB_DOCUMENT_ROOT=/project/public
+WEB_DOCUMENT_ROOT=/project/application/public
 WEB_ALIAS_DOMAIN=phalcon.local
 APPLICATION_CACHE=/project/cache
 APPLICATION_LOGS=/project/logs


### PR DESCRIPTION
Preinstall Phalcon dev-tools on app container.
Removed default application dir to support phalcon project init
After boot you can now run "`docker exec -t phalconcompose_app_1 phalcon project application simple`" to create a project skeleton

Solves #33 