### PR TITLE
Set UTF-8 as default

### DIFF
--- a/conf/mysql/my.cnf
+++ b/conf/mysql/my.cnf
@@ -1,0 +1,7 @@
+[mysqld]
+character_set_server=utf8
+character_set_filesystem=utf8
+collation-server=utf8_general_ci
+init-connect='SET NAMES utf8'
+init_connect='SET collation_connection = utf8_general_ci'
+skip-character-set-client-handshake

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,6 @@ services:
   mysql:
     restart: always
     image: mysql:5.7
-    command: mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci --init-connect='SET NAMES UTF8;'
     expose:
       - "3306"
     ports:
@@ -34,6 +33,7 @@ services:
     volumes:
       - ./data/mysql:/docker-entrypoint-initdb.d
       - mysql:/var/lib/mysql
+      - ./conf/mysql/my.cnf:/etc/mysql/conf.d/my.cnf
     env_file:
         - variables.env
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
   mysql:
     restart: always
     image: mysql:5.7
+    command: mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci --init-connect='SET NAMES UTF8;'
     expose:
       - "3306"
     ports:


### PR DESCRIPTION
Looking at projects like Invo it's good practice to have your DB in utf8/utf8_unicode_ci by default.
Currently it's in latin1_swedish_ci