### PR TITLE
php.ini not overriding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,8 +102,8 @@ services:
       - "443:443"
     volumes:
       - .:/project
-      - ./conf/php/cli.ini:/etc/php/7.0/cli/conf.d/100-custom.ini
-      - ./conf/php/fpm.ini:/etc/php/7.0/fpm/conf.d/100-custom.ini
+      - ./conf/php/cli.ini:/etc/php/7.0/cli/conf.d/99-custom.ini
+      - ./conf/php/fpm.ini:/etc/php/7.0/fpm/conf.d/99-custom.ini
     depends_on:
       - mysql
       - queue


### PR DESCRIPTION
File system looks at first character instead of the number. Causing 100 to be read before 98.